### PR TITLE
Fix Vite config stray text

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,6 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => ({
   // Use the site root for both development and production.
   base: '/',
-> main
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- clean up `vite.config.ts`

## Testing
- `npm install --loglevel=error`
- `npm run build --loglevel=error`


------
https://chatgpt.com/codex/tasks/task_e_685060b91d0c833296dd9b3880b7534b