### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ import { componentTagger } from "lovable-tagger";
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   // Use the site root for both development and production.
-  base: '/',
+  // The base path is set to the repository name for GitHub Pages deployments.
+  base: '/orbitale-animasie/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure `vite.config.ts` to use `/orbitale-animasie/` for GitHub Pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685063335a5083329bd1f3e9c23cf162